### PR TITLE
Single source clientid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
-config.py
 *.pyc
 .ipynb_checkpoints

--- a/README.md
+++ b/README.md
@@ -33,5 +33,6 @@ cm.update('notebook', {"oauth_client_id": c.NotebookApp.oauth_client_id})
 Replace the vars above with a working client_id / secret.
 
 Copy or symlink `extensions/gist.js` to your jupyter nbextensions directory.
+Running `jupyter --data-dir` should show the target location.
 
 Then run `jupyter notebook` from the repo root.

--- a/README.md
+++ b/README.md
@@ -7,13 +7,29 @@ Edit your `jupyter_notebook_config.py` file to add:
 ```python
 import os
 import sys
+from notebook.services.config import ConfigManager
+
+# Load extensions from the current directory
 sys.path.append(os.getcwd())
+
+# Register our server extension
 c = get_config()
 c.NotebookApp.server_extensions = [
     'create_gist'
 ]
+
+# Make the client id and secret available to the server.
+c.NotebookApp.oauth_client_id = "my_client_id"
+c.NotebookApp.oauth_client_secret = "my_client_secret"
+
+# Load the js extension and set some config values
+cm = ConfigManager()
+cm.update('notebook', {"load_extensions": {"gist": True}})
+
+# Make the client id *only* available to the client.
+cm.update('notebook', {"oauth_client_id": c.NotebookApp.oauth_client_id})
 ```
 
-Copy config.py.example to config.py and insert a working clientid / secret.
+Replace the vars above with a working client_id / secret.
 
-Then run `jupyter notebook`
+Then run `jupyter notebook` from the repo root.

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ c.NotebookApp.server_extensions = [
 ]
 
 # Make the client id and secret available to the server.
-c.NotebookApp.oauth_client_id = "my_client_id"
-c.NotebookApp.oauth_client_secret = "my_client_secret"
+c.NotebookApp.oauth_client_id = "my_client_id"         # FIXME
+c.NotebookApp.oauth_client_secret = "my_client_secret" # FIXME
 
 # Load the js extension and set some config values
 cm = ConfigManager()

--- a/README.md
+++ b/README.md
@@ -32,4 +32,6 @@ cm.update('notebook', {"oauth_client_id": c.NotebookApp.oauth_client_id})
 
 Replace the vars above with a working client_id / secret.
 
+Copy or symlink `extensions/gist.js` to your jupyter nbextensions directory.
+
 Then run `jupyter notebook` from the repo root.

--- a/config.py.example
+++ b/config.py.example
@@ -1,2 +1,0 @@
-OAUTH_CLIENT_ID = "my_oauth_clientid"
-OAUTH_CLIENT_SECRET = "topsecret"

--- a/create_gist.py
+++ b/create_gist.py
@@ -1,8 +1,13 @@
+from jupyter_core.paths import jupyter_config_dir
 from notebook.utils import url_path_join
 from notebook.base.handlers import IPythonHandler
+from notebook.services.config import ConfigManager
 import requests
 import json
-import config
+
+# Get Server config
+server_cm = ConfigManager(config_dir=jupyter_config_dir())
+cfg = server_cm.get('jupyter_notebook_config')
 
 class GistHandler(IPythonHandler):
     def get(self):
@@ -11,8 +16,8 @@ class GistHandler(IPythonHandler):
         access_code = args["code"][0].decode('ascii')
         response = requests.post("https://github.com/login/oauth/access_token",
             data = {
-                "client_id": config.OAUTH_CLIENT_ID,
-                "client_secret" : config.OAUTH_CLIENT_SECRET,
+                "client_id": cfg['NotebookApp']['oauth_client_id'],
+                "client_secret" : cfg['NotebookApp']['oauth_client_secret'],
                 "code" : access_code
             },
             headers = {"Accept" : "application/json"})

--- a/extensions/gist.js
+++ b/extensions/gist.js
@@ -15,13 +15,13 @@ cm = ConfigManager()
 cm.update('notebook', {"load_extensions": {"gist": True}})
 
 */
-define( function () {
 
-    var github_client_id = "a179eb5f91edcc084d8b";
+
+define(function (Jupyter) {
     var github_redirect_uri = "http://localhost:8888/create_gist";
+    var github_client_id = Jupyter.notebook.config.data.oauth_client_id;
 
     var gist_notebook = function () {
-
         // save the notebook and create a checkpoint
         IPython.notebook.save_checkpoint();
 
@@ -54,4 +54,6 @@ define( function () {
     return {
         load_ipython_extension: load_ipython_extension
     };
-});
+}
+
+);

--- a/extensions/gist.js
+++ b/extensions/gist.js
@@ -17,13 +17,13 @@ cm.update('notebook', {"load_extensions": {"gist": True}})
 */
 
 
-define(function (Jupyter) {
+define(function () {
     var github_redirect_uri = "http://localhost:8888/create_gist";
-    var github_client_id = Jupyter.notebook.config.data.oauth_client_id;
-
     var gist_notebook = function () {
         // save the notebook and create a checkpoint
         IPython.notebook.save_checkpoint();
+
+        var github_client_id = IPython.notebook.config.data.oauth_client_id;
 
         // start OAuth dialog
         window.open("https://github.com/login/oauth/authorize?client_id=" + github_client_id +


### PR DESCRIPTION
Set the client id and client secret in a single place, rather than setting in both the javascript and python code.