### PR TITLE
Load from notebook url

### DIFF
--- a/create_gist.py
+++ b/create_gist.py
@@ -3,10 +3,7 @@ from notebook.base.handlers import IPythonHandler
 from nbconvert.exporters.export import *
 import base64
 import json
-import os.path
 import requests
-import urllib.request
-import shutil
 import tornado
 import os
 
@@ -144,8 +141,10 @@ class DownloadNotebookHandler(IPythonHandler):
 
         file_path = os.path.join(os.getcwd(), nb_name)
 
-        with urllib.request.urlopen(nb_url) as response, open(file_path, 'wb') as out_file:
-            shutil.copyfileobj(response, out_file)
+        r = requests.get(nb_url, stream=True)
+        with open(file_path, 'wb') as fd:
+            for chunk in r.iter_content(1024): # TODO: check if this is a good chunk size
+                fd.write(chunk)
 
         self.write(nb_name)
         self.flush()

--- a/create_gist.py
+++ b/create_gist.py
@@ -107,12 +107,12 @@ class GistHandler(IPythonHandler):
         print("All done. . .")
 
 
-class DownloadGistHandler(IPythonHandler):
+class DownloadNotebookHandler(IPythonHandler):
     def post(self):
         post_data = tornado.escape.json_decode(self.request.body) 
 
         nb_url = post_data["nb_url"]
-        nb_name = post_data["nb_name"]
+        nb_name = base64.b64decode(post_data["nb_name"]).decode('utf-8')
 
         file_path = os.path.join(os.getcwd(), nb_name)
 
@@ -138,9 +138,9 @@ def load_jupyter_server_extension(nb_server_app):
     web_app = nb_server_app.web_app
     host_pattern = '.*$'
     route_pattern = url_path_join(web_app.settings['base_url'], '/create_gist')
-    download_gist_route_pattern = url_path_join(web_app.settings['base_url'], '/download_gist')
+    download_notebook_route_pattern = url_path_join(web_app.settings['base_url'], '/download_notebook')
 
 
-    web_app.add_handlers(host_pattern, [(route_pattern, GistHandler), (download_gist_route_pattern, DownloadGistHandler)])
+    web_app.add_handlers(host_pattern, [(route_pattern, GistHandler), (download_notebook_route_pattern, DownloadNotebookHandler)])
 
 

--- a/create_gist.py
+++ b/create_gist.py
@@ -138,8 +138,13 @@ class DownloadNotebookHandler(IPythonHandler):
 
         nb_url = post_data["nb_url"]
         nb_name = base64.b64decode(post_data["nb_name"]).decode('utf-8')
+        force_download = post_data["force_download"]
 
         file_path = os.path.join(os.getcwd(), nb_name)
+
+        if os.path.isfile(file_path):
+            if not force_download:
+                raise tornado.web.HTTPError(409, "ERROR: File already exists.")
 
         r = requests.get(nb_url, stream=True)
         with open(file_path, 'wb') as fd:

--- a/create_gist.py
+++ b/create_gist.py
@@ -5,20 +5,16 @@ import base64
 import json
 import os.path
 import requests
-<<<<<<< HEAD
 import urllib.request
 import shutil
 import tornado
 import os
-=======
-import tornado
 
 def raise_error(msg):
     raise tornado.web.HTTPError(500, "ERROR: " + msg)
 
 def raise_github_error(msg):
     raise tornado.web.HTTPError(500, "ERROR: Github returned the following: " + msg)
->>>>>>> origin/master
 
 # This handler will save out the notebook to GitHub gists in either a new Gist 
 # or it will create a new revision for a gist that already contains these two files.

--- a/create_gist.py
+++ b/create_gist.py
@@ -136,6 +136,7 @@ class GistHandler(IPythonHandler):
 
 class DownloadNotebookHandler(IPythonHandler):
     def post(self):
+        # url and filename are sent in a JSON encoded blob
         post_data = tornado.escape.json_decode(self.request.body) 
 
         nb_url = post_data["nb_url"]


### PR DESCRIPTION
Supports pasting in a Gist URL ([example](https://gist.github.com/yeah568/4e9e6e17ff55ca67afb1)) or a direct link to a .ipynb file ([example](https://gist.githubusercontent.com/yeah568/4e9e6e17ff55ca67afb1/raw/6ab5e44679a9f84bc81ae8a774ca0a857a1d891c/f.ipynb)).

This code parses the URL, sends the appropriate info to the server, which then downloads the file into the current working directory, and sends a filename back to the front end to open. Will currently break somewhat if using a raw .ipynb URL where the filename contains certain symbols.