### PR TITLE
Include 'gist.js' in the generated package.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,9 +32,10 @@ class InstallCommand(install):
 
 setup(
     name="jupyter-notebook-gist",
-    version="0.1.0",
+    version="0.1.1",
     description="Create a gist from the Jupyter Notebook UI",
     packages=["jupyter-notebook-gist"],
+    package_data={'': ['extensions/gist.js']},
     install_requires = ["ipython >= 4", "jupyter-pip", "jupyter", "requests"],
     url="https://github.com/mreid-moz/jupyter-notebook-gist",
     cmdclass = {"install": InstallCommand}


### PR DESCRIPTION
Required as part of #28 

By default it appears that only .py files are included in a PyPI
package. Add a snippet to explicitly include the 'gist.js' file.

Bump the package version too.

@musicaljelly could you review this change please?